### PR TITLE
Clarifying the use of data parameter in sh_binary rule

### DIFF
--- a/build_defs/shell.build_defs
+++ b/build_defs/shell.build_defs
@@ -51,7 +51,7 @@ def sh_binary(name:str, main:str|list&srcs, out:str="", deps:list=None, data:lis
       name (str): Name of the rule
       main (str | list): The script to execute after all files have been uncompressed
       out (str): Name of the output file to create. Defaults to name + .sh.
-      data (list): Runtime data for this rule.
+      data (list): Runtime dependencies and data for this rule.
       deps (list): Dependencies of this rule
       visibility (list): Visibility declaration of the rule.
       labels (list): List of labels.


### PR DESCRIPTION
We keep seeing folks uncertain on the usage of the data parameter inside sh_binary targets, and unsure how to call other binaries from sh_binary targets.

I think clarifying "Runtime data" to "Runtime dependencies" will improve this.

Though it could be useful to specify also that the built binary will be in the same location as the shell script, such that you can call a data dependency, `diff-checker` from the shell script with something along these lines:
```
bashSource="$(dirname "$(readlink -f "$0")")"
"$bashSource/diff-checker"
```

(I'm also not sure whether that's the most effective way to get the current path and call the data dependency)