### PR TITLE
`sh_binary`: require dependencies' run-time dependencies

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -1,5 +1,5 @@
 [Please]
-Version = >=17.0.0
+Version = >=17.26.0
 
 [PluginDefinition]
 Name = shell

--- a/build_defs/shell.build_defs
+++ b/build_defs/shell.build_defs
@@ -45,7 +45,7 @@ def sh_binary(name:str, main:str|list&srcs, out:str="", deps:list=None, data:lis
     The resulting script will contain three things:
     1) Code necessary to unzip dependent files.
     2) The user defined shell script.
-    3) The zipfile containing all dependent files.
+    3) The zipfile containing all dependent files, (but not those dependencies' run-time data).
 
     Args:
       name (str): Name of the rule
@@ -86,6 +86,7 @@ def sh_binary(name:str, main:str|list&srcs, out:str="", deps:list=None, data:lis
         deps = deps,
         binary = True,
         needs_transitive_deps = True,
+        runtime_deps_from_deps = True,
         labels = labels,
         visibility = visibility,
     )


### PR DESCRIPTION
`sh_binary` outputs a zip file with a short shell preamble that extracts the zip file's contents into a temporary directory before executing the main script. It doesn't collect the run-time dependencies of its own dependencies into the zip file it outputs, so those run-time dependencies must be built (and, if remote execution is enabled, uploaded to the remote worker) before the target is executed. Mark the dependencies' run-time dependencies as prerequisites for executing `sh_binary`'s output.